### PR TITLE
Fixed restrive condition from initial pull request

### DIFF
--- a/preventdelete.js
+++ b/preventdelete.js
@@ -213,6 +213,11 @@
 
 					if (self.check(prev))
 						return self.cancelKey(evt)
+					
+					if(range.startContainer === range.endContainer)
+						if(typeof(prev.prevObject[0].className) !== undefined) 
+							if(prev.prevObject[0].className === 'mceEditable')
+								return self.cancelKey(evt)					
 				}
 
 			})


### PR DESCRIPTION
The previous condition was too restrictive and wouldn't remove any lines when a multiline element came in existence.